### PR TITLE
Reduce timeout for redirect on login and register pages

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -72,7 +72,7 @@ function LoginForm() {
           case 201:
             setTimeout(() => {
               router.replace("/");
-            }, 4000);
+            }, 2000);
             resolve("Sukses masuk!");
             break;
 
@@ -94,7 +94,7 @@ function LoginForm() {
             reject("Gagal masuk! Silakan coba lagi!");
             break;
         }
-      }, 2000);
+      }, 1000);
     });
 
     toast.promise(toastPromise, {

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -80,7 +80,7 @@ function RegisterForm() {
           case 200:
             setTimeout(() => {
               router.replace("/");
-            }, 4000);
+            }, 2000);
             resolve();
             break;
 
@@ -91,7 +91,7 @@ function RegisterForm() {
             reject();
             break;
         }
-      }, 2000);
+      }, 1000);
     });
 
     toast.promise(toastPromise, {


### PR DESCRIPTION
The login and register pages have been updated to reduce the timeout for redirecting to the home page. This improves the user experience by reducing the waiting time.