### PR TITLE
Add avatar upload functionality to user settings page

### DIFF
--- a/src/utils/FetchUploadAvatar.ts
+++ b/src/utils/FetchUploadAvatar.ts
@@ -1,0 +1,33 @@
+"use server";
+
+import { cookies } from "next/headers";
+
+export async function FetchUploadAvatar(formData: FormData): Promise<boolean> {
+  // Get the environment variables
+  const BACKEND_URL = process.env.BACKEND_URL as string;
+  const HEADER_API_KEY = process.env.HEADER_API_KEY as string;
+
+  // Get the access token
+  const at = cookies().get("at");
+  if (!at) return false;
+
+  try {
+    // Fetch the user avatar
+    const res = await fetch(`${BACKEND_URL}/users/update/avatar`, {
+      method: "PATCH",
+      headers: {
+        Authorization: `Bearer ${at.value}`,
+        "x-api-key": HEADER_API_KEY,
+      },
+      body: formData,
+    });
+
+    // If not 200, return false
+    if (res.status !== 200) return false;
+
+    // Return true
+    return true;
+  } catch (error) {
+    return false;
+  }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,5 @@
 import { FetchRefreshToken } from "./FetchRefreshToken";
+import { FetchUploadAvatar } from "./FetchUploadAvatar";
 import { FetchUserLogin } from "./FetchUserLogin";
 import { FetchUserLogout } from "./FetchUserLogout";
 import { FetchUserRegister } from "./FetchUserRegister";
@@ -7,6 +8,7 @@ import { GetUserSession } from "./GetUserSession";
 
 export {
   FetchRefreshToken,
+  FetchUploadAvatar,
   FetchUserLogin,
   FetchUserLogout,
   FetchUserRegister,


### PR DESCRIPTION
This pull request adds the functionality to upload avatars on the user settings page. Users can now upload their profile pictures by clicking on the "Foto Profil" button and selecting an image file. The uploaded image is then sent to the server for processing.