### PR TITLE
Fix typo in default title for user not found page

### DIFF
--- a/src/app/user/[username]/layout.tsx
+++ b/src/app/user/[username]/layout.tsx
@@ -21,7 +21,7 @@ export async function generateMetadata({
 
   return {
     title: {
-      default: `Pengguna Tidak Ditemukan}`,
+      default: `Pengguna Tidak Ditemukan`,
       template: "%s » Reviu.ID",
     },
     description: "Halaman yang Anda cari tidak ditemukan.",


### PR DESCRIPTION
This pull request fixes a typo in the default title for the user not found page. The closing curly brace has been removed from the title, ensuring that it is displayed correctly.