### PR TITLE
Enable half-star ratings in FilmRating component

### DIFF
--- a/src/components/film/description/FilmRating.tsx
+++ b/src/components/film/description/FilmRating.tsx
@@ -67,6 +67,7 @@ const FilmRating: React.FC = () => {
         >
           <Rate
             disabled
+            allowHalf
             defaultValue={filmData.rating}
             style={{
               fontSize: 30,


### PR DESCRIPTION
This pull request enables the ability to have half-star ratings in the FilmRating component. Previously, only whole numbers were allowed for ratings. With this change, users can now give more precise ratings by selecting half-star increments.