### PR TITLE
Add open graph metadata to homepage

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,12 +4,30 @@ import { ConfigProvider } from "antd";
 import type { Metadata } from "next";
 import "./globals.css";
 
+const FRONTEND_URL = process.env.NEXT_PUBLIC_FRONTEND_URL!;
+
 export const metadata: Metadata = {
   title: {
     default: "Reviu.ID",
     template: "%s » Reviu.ID",
   },
   description: "Halaman utama Reviu.ID",
+  openGraph: {
+    title: "Reviu.ID",
+    description: "Halaman utama Reviu.ID",
+    url: FRONTEND_URL,
+    siteName: "Reviu.ID",
+    images: [
+      {
+        url: `${FRONTEND_URL}/logo.png`,
+        alt: "Reviu.ID",
+        width: 800,
+        height: 600,
+      },
+    ],
+    locale: "id_ID",
+    type: "website",
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
This pull request adds open graph metadata to the homepage of the Reviu.ID website. The metadata includes the title, description, URL, site name, and image for the homepage. This change enhances the visibility and branding of the website when shared on social media platforms.