### PR TITLE
Update metadata for authentication and film pages

### DIFF
--- a/src/app/(auth)/forgot-password/layout.tsx
+++ b/src/app/(auth)/forgot-password/layout.tsx
@@ -1,10 +1,29 @@
 import "@fontsource/poppins";
 import type { Metadata } from "next";
 
+const FRONTEND_URL = process.env.NEXT_PUBLIC_FRONTEND_URL!;
+
 export const metadata: Metadata = {
   title: "Lupa Kata Sandi",
   description:
     "Lupa kata sandi akun Reviu.ID? Atur ulang kata sandi Anda di sini.",
+  openGraph: {
+    title: "Lupa Kata Sandi » Reviu.ID",
+    description:
+      "Lupa kata sandi akun Reviu.ID? Atur ulang kata sandi Anda di sini.",
+    url: `${FRONTEND_URL}/forgot-password`,
+    siteName: "Reviu.ID",
+    images: [
+      {
+        url: `${FRONTEND_URL}/logo.png`,
+        alt: "Reviu.ID",
+        width: 800,
+        height: 600,
+      },
+    ],
+    locale: "id_ID",
+    type: "website",
+  },
 };
 
 export default function RootLayout({

--- a/src/app/(auth)/login/layout.tsx
+++ b/src/app/(auth)/login/layout.tsx
@@ -1,9 +1,27 @@
 import "@fontsource/poppins";
 import type { Metadata } from "next";
 
+const FRONTEND_URL = process.env.NEXT_PUBLIC_FRONTEND_URL!;
+
 export const metadata: Metadata = {
   title: "Masuk",
   description: "Masuk ke akun Reviu.ID untuk melanjutkan.",
+  openGraph: {
+    title: "Masuk » Reviu.ID",
+    description: "Masuk ke akun Reviu.ID untuk melanjutkan.",
+    url: `${FRONTEND_URL}/login`,
+    siteName: "Reviu.ID",
+    images: [
+      {
+        url: `${FRONTEND_URL}/logo.png`,
+        alt: "Reviu.ID",
+        width: 800,
+        height: 600,
+      },
+    ],
+    locale: "id_ID",
+    type: "website",
+  },
 };
 
 export default function RootLayout({

--- a/src/app/(auth)/logout/layout.tsx
+++ b/src/app/(auth)/logout/layout.tsx
@@ -1,9 +1,27 @@
 import "@fontsource/poppins";
 import type { Metadata } from "next";
 
+const FRONTEND_URL = process.env.NEXT_PUBLIC_FRONTEND_URL!;
+
 export const metadata: Metadata = {
   title: "Keluar",
   description: "Keluar dari akun Reviu.ID.",
+  openGraph: {
+    title: "Keluar » Reviu.ID",
+    description: "Keluar dari akun Reviu.ID.",
+    url: `${FRONTEND_URL}/logout`,
+    siteName: "Reviu.ID",
+    images: [
+      {
+        url: `${FRONTEND_URL}/logo.png`,
+        alt: "Reviu.ID",
+        width: 800,
+        height: 600,
+      },
+    ],
+    locale: "id_ID",
+    type: "website",
+  },
 };
 
 export default function RootLayout({

--- a/src/app/(auth)/register/layout.tsx
+++ b/src/app/(auth)/register/layout.tsx
@@ -2,9 +2,27 @@ import "@fontsource/poppins";
 import { App } from "antd";
 import type { Metadata } from "next";
 
+const FRONTEND_URL = process.env.NEXT_PUBLIC_FRONTEND_URL!;
+
 export const metadata: Metadata = {
   title: "Daftar",
   description: "Daftar akun Reviu.ID untuk melanjutkan.",
+  openGraph: {
+    title: "Daftar » Reviu.ID",
+    description: "Daftar akun Reviu.ID untuk melanjutkan.",
+    url: `${FRONTEND_URL}/register`,
+    siteName: "Reviu.ID",
+    images: [
+      {
+        url: `${FRONTEND_URL}/logo.png`,
+        alt: "Reviu.ID",
+        width: 800,
+        height: 600,
+      },
+    ],
+    locale: "id_ID",
+    type: "website",
+  },
 };
 
 export default function RootLayout({

--- a/src/app/film/[filmId]/layout.tsx
+++ b/src/app/film/[filmId]/layout.tsx
@@ -1,6 +1,8 @@
 import { GetFilmData } from "@/utils";
 import { Metadata } from "next";
 
+const FRONTEND_URL = process.env.NEXT_PUBLIC_FRONTEND_URL!;
+
 export async function generateMetadata({
   params,
 }: {
@@ -15,6 +17,25 @@ export async function generateMetadata({
         template: "%s » Reviu.ID",
       },
       description: "Halaman yang Anda cari tidak ditemukan.",
+      openGraph: {
+        title: {
+          default: `Film Tidak Ditemukan » Reviu.ID`,
+          template: "%s » Reviu.ID",
+        },
+        description: "Halaman yang Anda cari tidak ditemukan.",
+        url: `${FRONTEND_URL}/film/${params.filmId}`,
+        siteName: "Reviu.ID",
+        images: [
+          {
+            url: `${FRONTEND_URL}/logo.png`,
+            alt: "Reviu.ID",
+            width: 800,
+            height: 600,
+          },
+        ],
+        locale: "id_ID",
+        type: "website",
+      },
     };
   }
 
@@ -24,6 +45,25 @@ export async function generateMetadata({
       template: "%s » Reviu.ID",
     },
     description: response.synopsis,
+    openGraph: {
+      title: {
+        default: `${response.title} » Reviu.ID`,
+        template: "%s » Reviu.ID",
+      },
+      description: response.synopsis,
+      url: `${FRONTEND_URL}/film/${params.filmId}`,
+      siteName: "Reviu.ID",
+      images: [
+        {
+          url: `${FRONTEND_URL}/logo.png`,
+          alt: "Reviu.ID",
+          width: 800,
+          height: 600,
+        },
+      ],
+      locale: "id_ID",
+      type: "website",
+    },
   };
 }
 

--- a/src/app/film/layout.tsx
+++ b/src/app/film/layout.tsx
@@ -1,12 +1,33 @@
 import "@fontsource/poppins";
 import { Metadata } from "next";
 
+const FRONTEND_URL = process.env.NEXT_PUBLIC_FRONTEND_URL!;
+
 export const metadata: Metadata = {
   title: {
     default: `Daftar Film`,
     template: "%s » Reviu.ID",
   },
   description: "Daftar film yang tersedia di Reviu.ID",
+  openGraph: {
+    title: {
+      default: `Daftar Film » Reviu.ID`,
+      template: "%s » Reviu.ID",
+    },
+    description: "Daftar film yang tersedia di Reviu.ID",
+    url: `${FRONTEND_URL}/film`,
+    siteName: "Reviu.ID",
+    images: [
+      {
+        url: `${FRONTEND_URL}/logo.png`,
+        alt: "Reviu.ID",
+        width: 800,
+        height: 600,
+      },
+    ],
+    locale: "id_ID",
+    type: "website",
+  },
 };
 
 export default function RootLayout({

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,10 +11,10 @@ export const metadata: Metadata = {
     default: "Reviu.ID",
     template: "%s » Reviu.ID",
   },
-  description: "Halaman utama Reviu.ID",
+  description: "Halaman Utama Reviu.ID",
   openGraph: {
     title: "Reviu.ID",
-    description: "Halaman utama Reviu.ID",
+    description: "Berbagi Cerita, Menikmati Karya Film Indonesia!",
     url: FRONTEND_URL,
     siteName: "Reviu.ID",
     images: [

--- a/src/app/user/[username]/layout.tsx
+++ b/src/app/user/[username]/layout.tsx
@@ -2,6 +2,8 @@ import { GetUserProfile } from "@/utils";
 import "@fontsource/poppins";
 import { Metadata } from "next";
 
+const FRONTEND_URL = process.env.NEXT_PUBLIC_FRONTEND_URL!;
+
 export async function generateMetadata({
   params,
 }: {
@@ -9,22 +11,60 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const response = await GetUserProfile(params.username);
 
-  if (typeof response !== "number") {
+  if (typeof response === "number") {
     return {
       title: {
-        default: `${response.username}`,
+        default: `Pengguna Tidak Ditemukan`,
         template: "%s » Reviu.ID",
       },
-      description: response.biography,
+      description: "Halaman yang Anda cari tidak ditemukan.",
+      openGraph: {
+        title: {
+          default: `Pengguna Tidak Ditemukan » Reviu.ID`,
+          template: "%s » Reviu.ID",
+        },
+        description: "Halaman yang Anda cari tidak ditemukan.",
+        url: `${FRONTEND_URL}/user/${params.username}`,
+        siteName: "Reviu.ID",
+        images: [
+          {
+            url: `${FRONTEND_URL}/logo.png`,
+            alt: "Reviu.ID",
+            width: 800,
+            height: 600,
+          },
+        ],
+        locale: "id_ID",
+        type: "website",
+      },
     };
   }
 
   return {
     title: {
-      default: `Pengguna Tidak Ditemukan`,
+      default: `${response.username}`,
       template: "%s » Reviu.ID",
     },
-    description: "Halaman yang Anda cari tidak ditemukan.",
+    description: response.biography || "Tidak ada deskripsi.",
+    openGraph: {
+      title: {
+        default: `${response.username} » Reviu.ID`,
+        template: "%s » Reviu.ID",
+      },
+      description: response.biography || "Tidak ada deskripsi.",
+      url: `${FRONTEND_URL}/user/${params.username}`,
+      siteName: "Reviu.ID",
+      images: [
+        {
+          url: response.avatar || `${FRONTEND_URL}/logo.png`,
+          alt: response.username,
+          width: 800,
+          height: 600,
+        },
+      ],
+      locale: "id_ID",
+      type: "profile",
+    },
   };
 }
 

--- a/src/app/user/[username]/settings/layout.tsx
+++ b/src/app/user/[username]/settings/layout.tsx
@@ -1,5 +1,8 @@
 import { GetUserProfile } from "@/utils";
 import type { Metadata } from "next";
+import { OpenGraph } from "next/dist/lib/metadata/types/opengraph-types";
+
+const FRONTEND_URL = process.env.NEXT_PUBLIC_FRONTEND_URL!;
 
 export async function generateMetadata({
   params,
@@ -8,16 +11,35 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const response = await GetUserProfile(params.username);
 
-  if (typeof response !== "number") {
+  const openGraph: OpenGraph = {
+    title: "Reviu.ID",
+    description: "Berbagi Cerita, Menikmati Karya Film Indonesia!",
+    url: FRONTEND_URL,
+    siteName: "Reviu.ID",
+    images: [
+      {
+        url: `${FRONTEND_URL}/logo.png`,
+        alt: "Reviu.ID",
+        width: 800,
+        height: 600,
+      },
+    ],
+    locale: "id_ID",
+    type: "website",
+  };
+
+  if (typeof response === "number") {
     return {
-      title: "Pengaturan Akun",
-      description: "Keluar dari akun Reviu.ID.",
+      title: `Pengguna Tidak Ditemukan`,
+      description: "Halaman yang Anda cari tidak ditemukan.",
+      openGraph,
     };
   }
 
   return {
-    title: `Pengguna Tidak Ditemukan`,
-    description: "Halaman yang Anda cari tidak ditemukan.",
+    title: "Pengaturan Akun",
+    description: "Pengaturan akun pengguna Reviu.ID.",
+    openGraph,
   };
 }
 

--- a/src/components/main/FooterLayout.tsx
+++ b/src/components/main/FooterLayout.tsx
@@ -65,8 +65,8 @@ function Horizontal() {
         <Link href="/about-us" style={{ color: "white", listStyle: "none" }}>
           Tentang Kami
         </Link>
-        <Link href="/developer" style={{ color: "white", listStyle: "none" }}>
-          Developer
+        <Link href="/developers" style={{ color: "white", listStyle: "none" }}>
+          Pengembang
         </Link>
       </Space>
     </Flex>

--- a/src/components/main/FooterLayout.tsx
+++ b/src/components/main/FooterLayout.tsx
@@ -37,7 +37,7 @@ function Vertical() {
             href="/developers"
             style={{ color: "white", listStyle: "none" }}
           >
-            Developers
+            Pengembang
           </Link>
         </Space>
       </Space>


### PR DESCRIPTION
Update the metadata for the authentication pages (forgot-password, login, logout, register) and film pages to include open graph information. This includes setting the title, description, URL, site name, and image for each page. The metadata follows the id_ID locale and is of type "website". This change is necessary to enhance the visibility and branding of the Reviu.ID website.