### PR TITLE
Add server script and CD workflow for deployment

### DIFF
--- a/.github/workflows/cd_master.yml
+++ b/.github/workflows/cd_master.yml
@@ -1,0 +1,31 @@
+name: cd
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  cd:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Deploy Using ssh
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USERNAME }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          port: 22
+          script: |
+            cd ~/apps/reviuid-website-next
+            git pull origin master
+            git status
+            export NVM_DIR=~/.nvm
+            source ~/.nvm/nvm.sh
+            npm install
+            npm run build
+            pm2 reload reviuid-website
+            pm2 restart reviuid-website

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev -p 4000",
     "build": "next build",
     "start": "next start -p 4000",
-    "lint": "next lint"
+    "lint": "next lint",
+    "server": "pm2 start npm --name reviuid-website -- start"
   },
   "dependencies": {
     "@ant-design/icons": "^5.3.7",


### PR DESCRIPTION
This pull request adds a new "server" script to the package.json file, which allows for starting the server using pm2. Additionally, it adds a new GitHub Actions workflow file, `cd_master.yml`, for continuous deployment to the master branch. The workflow is triggered on push events to the master branch and deploys the latest changes to the production environment. The deployment process includes pulling the latest changes, installing dependencies, building the project, and restarting the server using PM2. This improves the deployment process and ensures that the latest changes are deployed to the production environment.