### PR TITLE
Remove unused image properties in film and user layout components

### DIFF
--- a/src/app/film/[filmId]/layout.tsx
+++ b/src/app/film/[filmId]/layout.tsx
@@ -44,12 +44,6 @@ export async function generateMetadata({
       siteName: "Reviu.ID",
       images: [
         {
-          url: filmData.poster,
-          alt: filmData.title,
-          width: 800,
-          height: 600,
-        },
-        {
           url: `${FRONTEND_URL}/logo.png`,
           alt: "Reviu.ID",
           width: 800,

--- a/src/app/user/[username]/layout.tsx
+++ b/src/app/user/[username]/layout.tsx
@@ -57,12 +57,6 @@ export async function generateMetadata({
       siteName: "Reviu.ID",
       images: [
         {
-          url: user.avatar,
-          alt: user.username,
-          width: 800,
-          height: 600,
-        },
-        {
           url: `${FRONTEND_URL}/logo.png`,
           alt: "Reviu.ID",
           width: 800,


### PR DESCRIPTION
This pull request removes the unused image properties in the film and user layout components. The `generateMetadata` function no longer includes the `poster` and `avatar` properties in the `images` array. This change improves the code by removing unnecessary code and reducing the size of the `images` array.