### PR TITLE
Add "AI Prompter" role to DeveloperPeople array

### DIFF
--- a/src/app/(about)/developers/page.tsx
+++ b/src/app/(about)/developers/page.tsx
@@ -64,7 +64,7 @@ const DeveloperPeople: Developer[] = [
     email: "timothy.paendong@binus.ac.id",
     avatar:
       "https://stbm7resourcesprod.blob.core.windows.net/profilepicture/a1f31845-6f13-4b1e-86e7-605853e6f2b3.jpg",
-    role: ["Team Leader", "Frontend Developer"],
+    role: ["Team Leader", "Frontend Developer", "AI Prompter"],
   },
 ];
 

--- a/src/types/developer.type.ts
+++ b/src/types/developer.type.ts
@@ -3,6 +3,7 @@ export type DeveloperRole =
   | "Frontend Developer"
   | "Backend Developer"
   | "UI/UX Designer"
+  | "AI Prompter"
   | "Database Administrator"
   | "System Administrator";
 


### PR DESCRIPTION
This refactor adds the "AI Prompter" role to the DeveloperPeople array in the developers page. It ensures that the role is included for the corresponding developer, improving the accuracy and completeness of the data.