### PR TITLE
Refactor: Set submitting state to true before validating formOTP in ForgotPasswordForm

### DIFF
--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -221,6 +221,7 @@ function ForgotPasswordForm() {
     formOTP
       .validateFields()
       .then(async (values) => {
+        setSubmitting(true);
         setConfirmModal(true);
         closeModal();
 
@@ -236,6 +237,7 @@ function ForgotPasswordForm() {
 
         setTimeout(() => {
           router.replace("/login");
+          setSubmitting(false);
         }, 2000);
       })
       .catch((error) => {


### PR DESCRIPTION
This refactor sets the submitting state to true before validating the formOTP in the ForgotPasswordForm component. This ensures that the form is in the submitting state while the validation is being performed. After the validation, the submitting state is set to false. This improves the user experience by providing visual feedback during the validation process.